### PR TITLE
fix witness goroutine bug

### DIFF
--- a/curp/witness.go
+++ b/curp/witness.go
@@ -1,8 +1,8 @@
 package curp
 
 import (
-	"fmt"
 	"net/rpc"
+	. "rtclbedit/shared"
 
 	mapset "github.com/deckarep/golang-set/v2"
 )
@@ -21,6 +21,7 @@ type DropArgs struct {
 type DropReply struct {
 }
 type RecordArgs struct {
+	Command interface{}
 }
 type RecordReply struct {
 }
@@ -29,12 +30,12 @@ type RecordReply struct {
  * RPC functions
  */
 func (w *Witness) Drop(args DropArgs, reply *DropReply) error { // dropRPC called by master
-	fmt.Println("RECEIVED DROP RPC MESSAGE")
+	DPrintf("%s receives Drop RPC %v+", w.name, args)
 	return nil
 }
 
 func (w *Witness) Record(args RecordArgs, reply *RecordReply) error { // recordRPC called by client
-	fmt.Println("RECEIVED RECORD RPC MESSAGE")
+	DPrintf("%s receives Record RPC %v+", w.name, args)
 	return nil
 }
 


### PR DESCRIPTION
main goroutine dies off before RPC calls are resolved hence witness(es) did not receive the RPC call. Add waitgroup to stop the main goroutine from exiting before RPC calls are fully resolved